### PR TITLE
Swift 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swift:5.10
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "7f449fa6ce1e24554ce8ffd57cfe2e44f7759d196e5e51fc463de2d33a5f7045",
   "pins" : [
     {
       "identity" : "swift-log",
@@ -10,5 +11,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/Sources/PlaygroundHandler.swift
+++ b/Sources/PlaygroundHandler.swift
@@ -25,9 +25,21 @@ public struct PlaygroundHandler: Sendable {
 
     private func timestamp() -> String {
         var buffer = [Int8](repeating: 0, count: 255)
+        #if os(Windows)
+        var timestamp = __time64_t()
+        _ = _time64(&timestamp)
+
+        var localTime = tm()
+        _ = _localtime64_s(&localTime, &timestamp)
+
+        _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
+        #else
         var timestamp = time(nil)
-        let localTime = localtime(&timestamp)
+        guard let localTime = localtime(&timestamp) else {
+            return "<unknown>"
+        }
         strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
+        #endif
         return buffer.withUnsafeBufferPointer {
             $0.withMemoryRebound(to: CChar.self) {
                 // swift-format-ignore: NeverForceUnwrap

--- a/Sources/PlaygroundHandler.swift
+++ b/Sources/PlaygroundHandler.swift
@@ -26,19 +26,19 @@ public struct PlaygroundHandler: Sendable {
     private func timestamp() -> String {
         var buffer = [Int8](repeating: 0, count: 255)
         #if os(Windows)
-        var timestamp = __time64_t()
-        _ = _time64(&timestamp)
+            var timestamp = __time64_t()
+            _ = _time64(&timestamp)
 
-        var localTime = tm()
-        _ = _localtime64_s(&localTime, &timestamp)
+            var localTime = tm()
+            _ = _localtime64_s(&localTime, &timestamp)
 
-        _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
+            _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
         #else
-        var timestamp = time(nil)
-        guard let localTime = localtime(&timestamp) else {
-            return "<unknown>"
-        }
-        strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
+            var timestamp = time(nil)
+            guard let localTime = localtime(&timestamp) else {
+                return "<unknown>"
+            }
+            strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
         #endif
         return buffer.withUnsafeBufferPointer {
             $0.withMemoryRebound(to: CChar.self) {


### PR DESCRIPTION
Swift Playground 4.6 bundles the Swift 6 toolchain, so we can expect swift-log-playground to always be compiled with Swift 6 or later.