### PR TITLE
fix: eliminate Foundation dependency

### DIFF
--- a/Sources/PlaygroundHandler.swift
+++ b/Sources/PlaygroundHandler.swift
@@ -1,5 +1,20 @@
-import Foundation
 import Logging
+
+#if canImport(Darwin)
+    import Darwin
+#elseif os(Windows)
+    import CRT
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Android)
+    import Android
+#elseif canImport(Musl)
+    import Musl
+#elseif canImport(WASILibc)
+    import WASILibc
+#else
+    #error("Unsupported runtime")
+#endif
 
 public struct PlaygroundHandler: Sendable {
     private let label: String


### PR DESCRIPTION
Although Foundation is imported to use `time`, `localtime`, and `strftime`, the dependency on Foundation was redundant since only libc is actually needed.