### PR TITLE
chore: enable development with Swift Playground on iPadOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 DerivedData/
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,33 @@ let package = Package(
             name: "LoggingPlayground",
             dependencies: [
                 .product(name: "Logging", package: "swift-log")
-            ]
+            ],
+            path: "Sources"
         )
     ]
 )
+
+// For development on iPadOS
+#if canImport(AppleProductTypes) && os(iOS)
+    import AppleProductTypes
+
+    package.platforms = [.iOS(.v18)]
+    package.products += [
+        .iOSApplication(
+            name: "Playground",
+            targets: ["Playground"],
+            supportedDeviceFamilies: [],
+            supportedInterfaceOrientations: []
+        )
+    ]
+    package.targets += [
+        .executableTarget(
+            name: "Playground",
+            dependencies: [
+                "LoggingPlayground",
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            path: "Playground"
+        )
+    ]
+#endif

--- a/Playground/Playground.swift
+++ b/Playground/Playground.swift
@@ -1,0 +1,23 @@
+import Logging
+import LoggingPlayground
+import SwiftUI
+
+let logger = Logger(label: "main")
+
+@main
+struct Playground: App {
+    init() {
+        LoggingSystem.bootstrap { PlaygroundHandler(label: $0) }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            Button("Test") {
+                logger.error("Lorem ipsum")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .hoverEffect()
+        }
+    }
+}


### PR DESCRIPTION
## How to develop on iPadOS

1. Clone this repository
    - To clone, I recommend using [Working Copy](https://workingcopyapp.com) or [a-Shell](https://holzschu.github.io/a-Shell_iOS/) (`lg2` command).
1. Rename swift-log-playground to swift-log-playground.swiftpm
1. Open it with Swift Playground