### PR TITLE
ci: pin GitHub Actions dependencies to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     container: swift:6.0
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/cache@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.3.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-24.04-arm
     container: swift:6.2
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - run: swift format lint -rsp .
   yamllint:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - run: yamllint --version
       - run: yamllint --strict --config-file .yamllint.yml .


### PR DESCRIPTION
This is a defense against supply chain attacks. Moreover, GitHub [recommends SHA
pinning](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) these days. Even with this change, dependabot should continue to function.